### PR TITLE
add test button

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,10 @@
   </head>
   <body>
     <script src="./bundle.js" type="text/javascript"></script>
-    <div>
-      <h1 style="position: absolute; top: 20%; left: 50%; transform: translate(-50%, -50%);">We made open source&nbsp;<a target="_blank" href="https://yoroi-wallet.com/">Yoroi Wallet</a>&nbsp;for you guys, keep hacking ;)</h1>
+    <div style="position: absolute; top: 20%; left: 50%; transform: translate(-50%, -50%);">
+      <h1>We made open source&nbsp;<a target="_blank" href="https://yoroi-wallet.com/">Yoroi Wallet</a>&nbsp;for you guys, keep hacking ;)</h1>
+      Test connection: 
+      <button id="versionButton" type="button" value="">Get Connect Device Version</button>
     </div>
   </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,18 @@
-'use strict'
+// @flow
 
 import YoroiLedgerBridge from './yoroi-ledger-bridge';
 
+let bridge;
+
 const init = async () => {
   try {
-    const bridge = new YoroiLedgerBridge();
+    bridge = new YoroiLedgerBridge();
+
+    window.onload = function(e) { 
+      document.getElementById("versionButton")
+        .addEventListener('click', async () => logConnectedDeviceVersion());
+    }
+
     if (bridge) {
       onSuccess(bridge);
     } else {
@@ -21,6 +29,21 @@ const onSuccess = async (bridge) => {
 
 const onError = (error) => {
   console.error(`[YOROI-LEDGER-BRIDGE] ERROR: initialization failed!!!\n${error}`);
+}
+
+/**
+ * Test Ledger connection : Console Log Connected Device Version
+ */
+const logConnectedDeviceVersion = async () => {
+  try {
+    const deviceVersion = await bridge.getConnectedDeviceVersion();
+    console.info('[YOROI-LEDGER-BRIDGE] Connected Ledger device version: '
+      + JSON.stringify(deviceVersion, null , 2));
+  } catch (error) {
+    console.error(error);
+    console.info('[YOROI-LEDGER-BRIDGE] '
+      + 'Is your Ledger Nano S device connected to your system\'s USB port?');
+  }
 }
 
 init();

--- a/src/yoroi-ledger-bridge.js
+++ b/src/yoroi-ledger-bridge.js
@@ -1,5 +1,4 @@
 // @flow
-'use strict'
 
 import 'babel-polyfill'; // this is need but no clear reasion why??
 import TransportU2F from '@ledgerhq/hw-transport-u2f';
@@ -24,6 +23,21 @@ export default class YoroiLedgerBridge {
 
   constructor () {
     this.addEventListeners();
+  }
+
+  /**
+   * @description Just to testing connectiong, result is not sent to iframe invoker
+   * 
+   * @returns {Promise<{major:number, minor:number, patch:number, flags:{isDebug:boolean}}>}
+   */
+  async getConnectedDeviceVersion(): Promise<GetVersionResponse> {
+    const transport = await TransportU2F.create();
+    try {
+      const adaApp = new AdaApp(transport);
+      return adaApp.getVersion();
+    } finally {
+      transport.close(); 
+    }
   }
 
   /**


### PR DESCRIPTION
Before we would automatically called the "getVersion" function when the page loads which was problematic.

Instead of replacing it entirely, it is now only triggered when you press a button.

Th `onload` event listener is required for the button to work. This is for the same reason that in Yoroi we needed a sleep(1000) as a quick-patch to get Ledger integration working correctly (need to wait for page to fully load). Yoroi-frontend will need the same event listener added to it for when we release Ledger support